### PR TITLE
Added encryption secret key which is missing in the quick start section

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -91,6 +91,7 @@ Run the following command in the directory containing your `docker-compose.yml` 
 export PROXEUS_EMAIL_FROM=<Your valid Sender Email Address>
 export PROXEUS_INFURA_API_KEY=<Your Infura project ID>
 export PROXEUS_SPARKPOST_API_KEY=<Your SparkPost API Key>
+export PROXEUS_ENCRYPTION_SECRET_KEY=<A 32-character randon string>
 export PROXEUS_BLOCKCHAIN_CONTRACT_ADDRESS=0x1d3e5c81bf4bc60d41a8fbbb3d1bae6f03a75f71
 export PROXEUS_ALLOW_HTTP=true
 docker-compose up


### PR DESCRIPTION
# Pull Request Details
Encryptio secret key in the quick start part is mising

## Description

export PROXEUS_ENCRYPTION_SECRET_KEY=<A 32-character randon string>

## Related Issue
[Issue template](issue_template.md)

<!--- This project only accepts pull requests related to open issues.  -->
<!--- If suggesting a new feature or change, please discuss it in an issue first  -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Because of this problem, the quickstart was not working as expected.

## How Has This Been Tested

The changes I made here were explained in another section, but they were missing here. I ran the program with these changes and it works as expected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[coding style](coding_style.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
